### PR TITLE
fix #7 to remove zope from list of requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,3 @@ requests==2.12.3
 scipy==0.18.1
 six==1.10.0
 xlrd==1.0.0
-zope.interface==4.3.2


### PR DESCRIPTION
removed because it is outdated